### PR TITLE
Add licensing instructions for OpenStax Poland

### DIFF
--- a/templates/openstax-poland-license/LICENSE.template
+++ b/templates/openstax-poland-license/LICENSE.template
@@ -1,0 +1,7 @@
+Copyright CURRENT YEAR OpenStax Poland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/templates/openstax-poland-license/README.md
+++ b/templates/openstax-poland-license/README.md
@@ -1,0 +1,27 @@
+# Software license for projects by OpenStax Poland
+
+## Applying the license
+
+1.  Copy `LICENSE.template` to the root directory of a project as `LICENSE`.
+
+2.  Edit it and change `CURRENT YEAR` in the copyright notice to current 
+    year (e.g. 2018).
+
+3.  Include the following notice at the beginning of each source file
+  
+    ```
+    Copyright CURRENT YEAR OpenStax Poland
+    Licensed under the MIT license. See LICENSE file in the project root for
+    full license text.
+    ```
+
+    Again, changing `CURRENT YEAR` to current year.
+
+4.  Include appropriate license information in a packaging system used by 
+    the project:
+
+    - For [npm](npmjs.com): in `package.json` add `"license": "MIT"`.
+    - For [Rust Cargo](crates.io): in `Cargo.toml` add `license = "MIT"` to
+      the `[package]` section.
+    - For Python: add `license="MIT"` as a keyword argument to invocation
+      of the `setup()` function in `setup.py`


### PR DESCRIPTION
It's best to see it in [GitHub's interface](https://github.com/katalysteducation/storehouse/tree/openstax-pl-license-template/templates/openstax-poland-license).